### PR TITLE
fix: mend typo in attachment endpoint

### DIFF
--- a/push_to_3yourmind/api/user_panel.py
+++ b/push_to_3yourmind/api/user_panel.py
@@ -397,6 +397,6 @@ class UserPanelAPI(BaseAPI):
         attachment_file_contents = utils.extract_file_content(attachment_file)
         return self._request(
             "POST",
-            f"user-panel/catalogue/{catalog_item_id}/attachments/",
+            f"user-panel/catalog/{catalog_item_id}/attachments/",
             files={"file": attachment_file_contents},
         )


### PR DESCRIPTION
I did a shameful type that I did not notice somehow